### PR TITLE
Preserve unknown cookie attributes

### DIFF
--- a/test/Cookie/ResponseCookieTest.php
+++ b/test/Cookie/ResponseCookieTest.php
@@ -248,4 +248,14 @@ class ResponseCookieTest extends TestCase
 
         $cookie->withValue('what is this');
     }
+
+    public function testPreservesUnknownAttributes()
+    {
+        $cookie = ResponseCookie::fromHeader('key=value; HttpOnly; SameSite=strict;Foobar');
+        $this->assertNotNull($cookie);
+        $this->assertSame('key', $cookie->getName());
+        $this->assertSame('value', $cookie->getValue());
+        $this->assertTrue($cookie->isHttpOnly());
+        $this->assertSame('key=value; HttpOnly; SameSite=strict; Foobar', (string) $cookie);
+    }
 }


### PR DESCRIPTION
Fixes #2.

Unknown attributes are intentionally only preserved when using `fromHeader()`.