### PR TITLE
Add branch-alias in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
     "scripts": {
         "test": "php vendor/bin/phpunit",
         "code-style": "php vendor/bin/php-cs-fixer fix"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
The missing branch-alias prevents us from installing dev-master easily.