### PR TITLE
Add function to split comma-separated fields

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -3,6 +3,34 @@
 namespace Amp\Http;
 
 /**
+ * Splits comma-separated fields into individual components.
+ *
+ * @param Message $message
+ * @param string  $headerName
+ *
+ * @return string[]
+ */
+function splitField(Message $message, string $headerName): array
+{
+    $header = \implode(', ', $message->getHeaderArray($headerName));
+
+    if ($header === '') {
+        return [];
+    }
+
+    \preg_match_all('(([^",]+(?:"((?:[^\\\\"]|\\\\.)*)"|([^,]*))?),?\s*)', $header, $matches, \PREG_SET_ORDER);
+
+    $values = [];
+
+    foreach ($matches as $match) {
+        // decode escaped characters
+        $values[] = \preg_replace('(\\\\(.))', '\1', \trim($match[1]));
+    }
+
+    return $values;
+}
+
+/**
  * @param Message $message
  * @param string  $headerName
  *

--- a/test/SplitFieldTest.php
+++ b/test/SplitFieldTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Amp\Http;
+
+use PHPUnit\Framework\TestCase;
+
+class SplitFieldTest extends TestCase
+{
+    public function test()
+    {
+        self::assertSame([
+            'no-cache',
+            'no-store',
+            'must-revalidate',
+        ], $this->parse('no-cache, no-store, must-revalidate'));
+
+        self::assertSame([
+            'public',
+            'max-age=31536000',
+        ], $this->parse('public, max-age=31536000'));
+
+        self::assertSame([
+            'private="foo, bar"',
+            'max-age=31536000',
+        ], $this->parse('private="foo, bar", max-age=31536000'));
+
+        self::assertSame([
+            'private="foo',
+            'bar',
+            'max-age=31536000',
+        ], $this->parse('private="foo, bar, max-age=31536000'));
+
+        self::assertSame([
+            'private="foo"bar"',
+            'max-age=31536000',
+        ], $this->parse('private="foo\"bar", max-age=31536000'));
+
+        self::assertSame([
+            'private="foo""bar"',
+            'max-age=31536000',
+        ], $this->parse('private="foo\"\"bar", max-age=31536000'));
+
+        self::assertSame([
+            'private="foo\\"',
+            'bar',
+        ], $this->parse('private="foo\\\\", bar'));
+
+        self::assertSame([
+            'private="foo"',
+            'private=bar',
+        ], $this->parse('private="foo", private=bar'));
+    }
+
+    private function parse(string $headerValue)
+    {
+        return splitField($this->createMessage(['cache-control' => $headerValue]), 'cache-control');
+    }
+
+    private function createMessage(array $headers): Message
+    {
+        return new class($headers) extends Message {
+            public function __construct(array $headers)
+            {
+                $this->setHeaders($headers);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Useful when all you care about is splitting on commas, not generating key-value pairs.

@kelunik Can you review the regex to make sure it makes sense.