### PR TITLE
Added check to discard phantom request cookies

### DIFF
--- a/src/Cookie/RequestCookie.php
+++ b/src/Cookie/RequestCookie.php
@@ -34,6 +34,11 @@ final class RequestCookie
 
         try {
             foreach ($cookies as $cookie) {
+                // Ignore zero-length cookie.
+                if ($cookie === '') {
+                    continue;
+                }
+
                 $parts = \explode('=', $cookie, 2);
 
                 if (2 !== \count($parts)) {

--- a/test/Cookie/RequestCookieTest.php
+++ b/test/Cookie/RequestCookieTest.php
@@ -20,6 +20,16 @@ class RequestCookieTest extends TestCase
         $this->assertSame([], RequestCookie::fromHeader("a=1; b"));
     }
 
+    /**
+     * Tests that when a zero-length phantom cookie is trailing due to the terminating semi-colon, it is simply
+     * discarded without impacting any other cookies present.
+     */
+    public function testZeroLengthTrailingCookie(): void
+    {
+        self::assertCount(1, $cookies = RequestCookie::fromHeader('a=1;'));
+        self::assertEquals([new RequestCookie('a', '1')], $cookies);
+    }
+
     public function testInvalidCookieName()
     {
         $this->expectException(InvalidCookieException::class);


### PR DESCRIPTION
This is an improvement over the original implementation because the previous behaviour was to discard the entire set of request cookies if a phantom cookie was encountered, which is probably never the result we want.

Note this still buckles under `a=1; ` (notice the trailing space). This could be solved by trimming the cookie before the comparison to the empty string, but this is left as an exercise for someone who gives more of a shit than I currently do.