### PR TITLE
fix validate header with dot

### DIFF
--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -208,7 +208,7 @@ abstract class HttpMessage
 
     private function isNameValid(string $name): bool
     {
-        return (bool) \preg_match('/^[A-Za-z0-9`~!#$%^&_|\'\-:]+$/', $name);
+        return (bool) \preg_match('/^[A-Za-z0-9`~!#$%^&_|\'\-*+.]+$/', $name);
     }
 
     /**


### PR DESCRIPTION
On received header `client.limit: 100` an error is thrown `Invalid header name`