### PR TITLE
Add header with valid types

### DIFF
--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -123,17 +123,18 @@ abstract class HttpMessage
      * Sets the named header to the given value.
      *
      * @param non-empty-string $name
-     * @param string|array<string> $value
+     * @param string|array<string>|int|float $value
      *
      * @throws \Error If the header name or value is invalid.
      */
-    protected function setHeader(string $name, array|string $value): void
+    protected function setHeader(string $name, array|string|int|float $value): void
     {
         \assert($this->isNameValid($name), "Invalid header name");
 
         $lcName = HEADER_LOWER[$name] ?? \strtolower($name);
 
         if (!\is_array($value)) {
+            $value = \strval($value);
             \assert($this->isValueValid([$value]), "Invalid header value");
             $this->headers[$lcName] = [$value];
             $this->headerCase[$lcName] = [$name];
@@ -157,17 +158,18 @@ abstract class HttpMessage
      * Adds the value to the named header, or creates the header with the given value if it did not exist.
      *
      * @param non-empty-string $name
-     * @param string|array<string> $value
+     * @param string|array<string>|int|float $value
      *
      * @throws \Error If the header name or value is invalid.
      */
-    protected function addHeader(string $name, array|string $value): void
+    protected function addHeader(string $name, array|string|int|float $value): void
     {
         \assert($this->isNameValid($name), "Invalid header name");
 
         $lcName = HEADER_LOWER[$name] ?? \strtolower($name);
 
         if (!\is_array($value)) {
+            $value = \strval($value);
             \assert($this->isValueValid([$value]), "Invalid header value");
             $this->headers[$lcName][] = $value;
             $this->headerCase[$lcName][] = $name;

--- a/test/HttpMessageTest.php
+++ b/test/HttpMessageTest.php
@@ -21,12 +21,12 @@ class TestHttpMessage extends HttpMessage
         parent::replaceHeaders($headers);
     }
 
-    public function setHeader(string $name, $value): void
+    public function setHeader(string|int|float $name, $value): void
     {
         parent::setHeader($name, $value);
     }
 
-    public function addHeader(string $name, $value): void
+    public function addHeader(string|int|float $name, $value): void
     {
         parent::addHeader($name, $value);
     }
@@ -99,6 +99,9 @@ class HttpMessageTest extends TestCase
 
         $message->addHeader('bar', []);
         $this->assertSame(['bar', 'baz'], $message->getHeaderArray('bar'));
+
+        $message->addHeader('x-foo', 10);
+        $this->assertSame(['10'], $message->getHeaderArray('x-foo'));
     }
 
     public function testSetAndReplaceHeaders(): void
@@ -132,6 +135,9 @@ class HttpMessageTest extends TestCase
         $message->setHeader('bar', ['biz', 'baz']);
         $this->assertSame(['biz', 'baz'], $message->getHeaderArray('bar'));
         $this->assertSame('biz', $message->getHeader('bar'));
+
+        $message->setHeader('x-foo', 10);
+        $this->assertSame('10', $message->getHeader('x-foo'));
     }
 
     public function testInvalidName(): void


### PR DESCRIPTION
I catch error when add header with timestamp:
```php
$request->setHeaders(array_filter([
	'apns-topic'      => $topic,
	'apns-expiration' => time() + $ttl,
]));
```
It's very stupid to make sure that all data types match the string.