### PR TITLE
Allow commas in cookie values

### DIFF
--- a/src/Cookie/RequestCookie.php
+++ b/src/Cookie/RequestCookie.php
@@ -13,7 +13,7 @@ namespace Amp\Http\Cookie;
 final class RequestCookie implements \Stringable
 {
     private const NAME_REGEX = /** @lang RegExp */ '(^[^()<>@,;:\\\"/[\]?={}\x01-\x20\x7F]*+$)';
-    private const VALUE_REGEX = /** @lang RegExp */ '(^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*+$)';
+    private const VALUE_REGEX = /** @lang RegExp */ '(^[\x21\x23-\x3A\x3C-\x5B\x5D-\x7E]*+$)';
 
     /**
      * Parses the cookies from a 'cookie' header.

--- a/src/Cookie/ResponseCookie.php
+++ b/src/Cookie/ResponseCookie.php
@@ -13,7 +13,7 @@ namespace Amp\Http\Cookie;
 final class ResponseCookie implements \Stringable
 {
     private const NAME_REGEX = /** @lang RegExp */ '(^[^()<>@,;:\\\"/[\]?={}\x01-\x20\x7F]*+$)';
-    private const VALUE_REGEX = /** @lang RegExp */ '(^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*+$)';
+    private const VALUE_REGEX = /** @lang RegExp */ '(^[\x21\x23-\x3A\x3C-\x5B\x5D-\x7E]*+$)';
 
     private static array $dateFormats = [
         'D, d M Y H:i:s T',

--- a/test/Cookie/RequestCookieTest.php
+++ b/test/Cookie/RequestCookieTest.php
@@ -14,7 +14,7 @@ class RequestCookieTest extends TestCase
         $this->assertEquals([new RequestCookie("a", "1"), new RequestCookie("b", "2")], RequestCookie::fromHeader("a=1; b=2"));
         $this->assertEquals([new RequestCookie("a", "1"), new RequestCookie("b", "2")], RequestCookie::fromHeader("a=1 ;b=2"));
         $this->assertEquals([new RequestCookie("a", "1"), new RequestCookie("b", "-2")], RequestCookie::fromHeader("a=1; b = -2"));
-        $this->assertEquals([], RequestCookie::fromHeader("a=1; b=2,2"));
+        $this->assertEquals([new RequestCookie("a", "1"), new RequestCookie("b", "2,2")], RequestCookie::fromHeader("a=1; b=2,2"));
         $this->assertEquals([], RequestCookie::fromHeader("a=1; b=2 2"));
         $this->assertEquals([], RequestCookie::fromHeader("a=1; b"));
     }


### PR DESCRIPTION
While commas in cookie values are not allowed by RFC6265 (see [4.1.1 Syntax](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1)), it seems many modern browsers including Chrome and Firefox allow commas to be in cookie values.

Issue in .NET: https://github.com/dotnet/runtime/issues/58773
Issue in Go: https://github.com/golang/go/issues/7243

Ping @PeeHaa, since you raised this issue.